### PR TITLE
Fixed ENCRYPTION_FAILED error in devices with API level lower than 18

### DIFF
--- a/app/src/main/java/com/microsoft/office365/connect/ConnectActivity.java
+++ b/app/src/main/java/com/microsoft/office365/connect/ConnectActivity.java
@@ -6,6 +6,7 @@ package com.microsoft.office365.connect;
 import android.content.Intent;
 import android.os.Build;
 import android.os.Bundle;
+import android.provider.Settings;
 import android.support.v7.app.ActionBarActivity;
 import android.util.Log;
 import android.view.View;
@@ -21,7 +22,6 @@ import com.microsoft.aad.adal.AuthenticationResult;
 import com.microsoft.aad.adal.AuthenticationSettings;
 
 import java.net.URI;
-import java.security.SecureRandom;
 import java.util.UUID;
 
 /**
@@ -141,12 +141,21 @@ public class ConnectActivity extends ActionBarActivity {
     }
 
     /**
-     * Randomly generates an encryption key for devices with API level lower than 18.
+     * Generates an encryption key for devices with API level lower than 18 using the
+     * ANDROID_ID value as a seed.
+     * In production scenarios, you should come up with your own implementation of this method.
+     * Consider that your algorithm must return the same key so it can encrypt/decrypt values
+     * successfully.
      * @return The encryption key in a 32 byte long array.
      */
     protected byte[] generateSecretKey() {
         byte[] key = new byte[32];
-        new SecureRandom().nextBytes(key);
+        byte[] android_id = Settings.Secure.ANDROID_ID.getBytes();
+
+        for(int i = 0; i < key.length; i++){
+            key[i] = android_id[i % android_id.length];
+        }
+
         return key;
     }
 

--- a/app/src/main/java/com/microsoft/office365/connect/ConnectActivity.java
+++ b/app/src/main/java/com/microsoft/office365/connect/ConnectActivity.java
@@ -21,6 +21,7 @@ import com.google.common.util.concurrent.SettableFuture;
 import com.microsoft.aad.adal.AuthenticationResult;
 import com.microsoft.aad.adal.AuthenticationSettings;
 
+import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.util.UUID;
 
@@ -148,9 +149,16 @@ public class ConnectActivity extends ActionBarActivity {
      * successfully.
      * @return The encryption key in a 32 byte long array.
      */
-    protected byte[] generateSecretKey() {
+    private byte[] generateSecretKey() {
         byte[] key = new byte[32];
-        byte[] android_id = Settings.Secure.ANDROID_ID.getBytes();
+        byte[] android_id = null;
+
+        try{
+            android_id = Settings.Secure.ANDROID_ID.getBytes("UTF-8");
+        } catch (UnsupportedEncodingException e){
+            Log.e(TAG, "generateSecretKey - " + e.getMessage());
+            showEncryptionKeyErrorUI();
+        }
 
         for(int i = 0; i < key.length; i++){
             key[i] = android_id[i % android_id.length];


### PR DESCRIPTION
Encryption/decryption succeeds the first time the app runs, but it fails the second time because we were generating a different key every time the app is started.
Updated the method `ConnectActivity.generateSecretKey()` to return the same value every time.

```
 ENCRYPTION_FAILED:Decryption failure ver:1.1.2
    java.security.DigestException
            at com.microsoft.aad.adal.StorageHelper.assertMac(StorageHelper.java:407)
            at com.microsoft.aad.adal.StorageHelper.decrypt(StorageHelper.java:373)
            at com.microsoft.aad.adal.DefaultTokenCacheStore.decrypt(DefaultTokenCacheStore.java:114)
            at com.microsoft.aad.adal.DefaultTokenCacheStore.getItem(DefaultTokenCacheStore.java:139)
            at com.microsoft.aad.adal.AuthenticationContext.getRefreshToken(AuthenticationContext.java:1414)
            at com.microsoft.aad.adal.AuthenticationContext.localFlow(AuthenticationContext.java:1245)
            at com.microsoft.aad.adal.AuthenticationContext.acquireTokenAfterValidation(AuthenticationContext.java:1217)
            at com.microsoft.aad.adal.AuthenticationContext.acquireTokenLocalCall(AuthenticationContext.java:1119)
            at com.microsoft.aad.adal.AuthenticationContext.access$600(AuthenticationContext.java:58)
            at com.microsoft.aad.adal.AuthenticationContext$4.call(AuthenticationContext.java:1068)
            at com.microsoft.aad.adal.AuthenticationContext$4.call(AuthenticationContext.java:1063)
            at java.util.concurrent.FutureTask$Sync.innerRun(FutureTask.java:305)
            at java.util.concurrent.FutureTask.run(FutureTask.java:137)
            at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1076)
            at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:569)
            at java.lang.Thread.run(Thread.java:856)

```
