### PR TITLE
Handle authentication error when user tries to sign in with MSA

### DIFF
--- a/app/src/main/java/com/microsoft/office365/connect/AuthenticationController.java
+++ b/app/src/main/java/com/microsoft/office365/connect/AuthenticationController.java
@@ -119,6 +119,10 @@ public class AuthenticationController {
                                         resourceId,
                                         Constants.CLIENT_ID);
                                 result.set(authenticationResult);
+                            } else if (authenticationResult != null){
+                                // This condition can happen if user signs in with an MSA account
+                                // instead of an Office 365 account
+                                result.setException(new Throwable(authenticationResult.getErrorDescription()));
                             }
                         }
 

--- a/app/src/main/java/com/microsoft/office365/connect/AuthenticationController.java
+++ b/app/src/main/java/com/microsoft/office365/connect/AuthenticationController.java
@@ -6,7 +6,10 @@
 package com.microsoft.office365.connect;
 
 import android.app.Activity;
+import android.os.Build;
 import android.util.Log;
+import android.webkit.CookieManager;
+import android.webkit.CookieSyncManager;
 
 import com.google.common.util.concurrent.SettableFuture;
 import com.microsoft.aad.adal.AuthenticationCallback;
@@ -164,5 +167,30 @@ public class AuthenticationController {
             return false;
         }
         return true;
+    }
+
+    /**
+     * Disconnects the app from Office 365 by clearing the token cache, setting the client objects
+     * to null, and clearing the app cookies from the device.
+     */
+    public void disconnect(){
+        //Clear tokens.
+        if(getAuthenticationContext().getCache() != null) {
+            getAuthenticationContext().getCache().removeAll();
+        }
+
+        //Reset controller objects.
+        MailController.resetInstance();
+        DiscoveryController.resetInstance();
+        AuthenticationController.resetInstance();
+
+        //Clear cookies.
+        if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP){
+            CookieManager.getInstance().removeSessionCookies(null);
+            CookieManager.getInstance().flush();
+        }else{
+            CookieManager.getInstance().removeSessionCookie();
+            CookieSyncManager.getInstance().sync();
+        }
     }
 }

--- a/app/src/main/java/com/microsoft/office365/connect/ConnectActivity.java
+++ b/app/src/main/java/com/microsoft/office365/connect/ConnectActivity.java
@@ -117,6 +117,8 @@ public class ConnectActivity extends ActionBarActivity {
             @Override
             public void onFailure(final Throwable t) {
                 Log.e(TAG, "onCreate - " + t.getMessage());
+                // We need to make sure that there are no cookies stored with the failed auth
+                AuthenticationController.getInstance().disconnect();
                 showConnectErrorUI();
             }
         });

--- a/app/src/main/java/com/microsoft/office365/connect/SendMailActivity.java
+++ b/app/src/main/java/com/microsoft/office365/connect/SendMailActivity.java
@@ -93,7 +93,7 @@ public class SendMailActivity extends ActionBarActivity {
                                         serviceInfo.getserviceEndpointUri()
                                 );
 
-                        try{
+                        try {
                             // Since we are no longer on the UI thread,
                             // we can call this method synchronously without blocking the UI
                             Boolean mailSent = MailController.getInstance().sendMail(
@@ -106,7 +106,7 @@ public class SendMailActivity extends ActionBarActivity {
                             ).get();
                             Log.i(TAG, "sendMailToRecipient - Mail sent");
                             showSendMailSuccessUI();
-                        } catch (InterruptedException | ExecutionException e){
+                        } catch (InterruptedException | ExecutionException e) {
                             Log.e(TAG, "onSendMailButtonClick - " + e.getMessage());
                             showSendMailErrorUI();
                         }
@@ -118,35 +118,6 @@ public class SendMailActivity extends ActionBarActivity {
                         showDiscoverErrorUI();
                     }
                 });
-    }
-
-    /**
-     * Disconnects the app from Office 365 by clearing the token cache, setting the client objects
-     * to null, and clearing the app cookies from the device.
-     */
-    private void disconnect(){
-        //Clear tokens.
-        AuthenticationController
-                .getInstance()
-                .getAuthenticationContext()
-                .getCache()
-                .removeAll();
-
-        //Reset controller objects.
-        MailController.resetInstance();
-        DiscoveryController.resetInstance();
-        AuthenticationController.resetInstance();
-
-        //Clear cookies.
-        if(Build.VERSION.SDK_INT >= 21){
-            CookieManager.getInstance().removeSessionCookies(null);
-            CookieManager.getInstance().flush();
-        }else{
-            CookieManager.getInstance().removeSessionCookie();
-            CookieSyncManager.getInstance().sync();
-        }
-
-        showDisconnectSuccessUI();
     }
 
     @Override
@@ -161,7 +132,8 @@ public class SendMailActivity extends ActionBarActivity {
         try {
             switch (item.getItemId()) {
                 case R.id.disconnectMenuitem:
-                    disconnect();
+                    AuthenticationController.getInstance().disconnect();
+                    showDisconnectSuccessUI();
                     Intent connectIntent = new Intent(this, ConnectActivity.class);
                     startActivity(connectIntent);
                     return true;


### PR DESCRIPTION
When a user tries to sign in with an Microsoft account (MSA) the app hangs. Furthermore, when user tries to sign in with an MSA, ADAL doesn't use the regular onFailure callbacks, instead the authenticationResult.getStatus == Failed, so I needed to handle this accordingly.
One last update is that the cookies need to be reset if the user tried to sign in with an MSA.
