### PR TITLE
Changed the app with a few improvements to the auth code

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -3,6 +3,24 @@
   <component name="EntryPointsManager">
     <entry_points version="2.0" />
   </component>
+  <component name="JavadocGenerationManager">
+    <option name="OUTPUT_DIRECTORY" />
+    <option name="OPTION_SCOPE" value="protected" />
+    <option name="OPTION_HIERARCHY" value="true" />
+    <option name="OPTION_NAVIGATOR" value="true" />
+    <option name="OPTION_INDEX" value="true" />
+    <option name="OPTION_SEPARATE_INDEX" value="true" />
+    <option name="OPTION_DOCUMENT_TAG_USE" value="false" />
+    <option name="OPTION_DOCUMENT_TAG_AUTHOR" value="false" />
+    <option name="OPTION_DOCUMENT_TAG_VERSION" value="false" />
+    <option name="OPTION_DOCUMENT_TAG_DEPRECATED" value="true" />
+    <option name="OPTION_DEPRECATED_LIST" value="true" />
+    <option name="OTHER_OPTIONS" value="" />
+    <option name="HEAP_SIZE" />
+    <option name="LOCALE" />
+    <option name="OPEN_IN_BROWSER" value="true" />
+    <option name="OPTION_INCLUDE_LIBS" value="false" />
+  </component>
   <component name="ProjectInspectionProfilesVisibleTreeState">
     <entry key="Project Default">
       <profile-state>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+    <mapping directory="" vcs="" />
   </component>
 </project>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -32,6 +32,9 @@
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value="com.microsoft.office365.connect.ConnectActivity" />
         </activity>
+        <activity
+            android:name="com.microsoft.aad.adal.AuthenticationActivity"
+            android:screenOrientation="portrait" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/microsoft/office365/connect/AuthenticationManager.java
+++ b/app/src/main/java/com/microsoft/office365/connect/AuthenticationManager.java
@@ -169,6 +169,8 @@ public class AuthenticationManager {
                                     Constants.CLIENT_ID);
                             authenticationCallback.onSuccess(authenticationResult);
                         } else if (authenticationResult != null) {
+                            // We need to make sure that there is no data stored with the failed auth
+                            AuthenticationManager.getInstance().disconnect();
                             // This condition can happen if user signs in with an MSA account
                             // instead of an Office 365 account
                             authenticationCallback.onError(
@@ -182,6 +184,8 @@ public class AuthenticationManager {
 
                     @Override
                     public void onError(Exception e) {
+                        // We need to make sure that there is no data stored with the failed auth
+                        AuthenticationManager.getInstance().disconnect();
                         authenticationCallback.onError(e);
                     }
                 }

--- a/app/src/main/java/com/microsoft/office365/connect/AuthenticationManager.java
+++ b/app/src/main/java/com/microsoft/office365/connect/AuthenticationManager.java
@@ -139,7 +139,7 @@ public class AuthenticationManager {
      * Calls {@link AuthenticationManager#authenticateSilent(AuthenticationCallback)} otherwise.
      * @param authenticationCallback The callback to notify when the processing is finished.
      */
-    public void connect(final AuthenticationCallback authenticationCallback) {
+    public void connect(final AuthenticationCallback<AuthenticationResult> authenticationCallback) {
         if (verifyAuthenticationContext()) {
             if(isConnected()) {
                 authenticateSilent(authenticationCallback);
@@ -148,10 +148,9 @@ public class AuthenticationManager {
             }
         } else {
             Log.e(TAG, "connect - Auth context verification failed. Did you set a context activity?");
-            AuthenticationException authenticationException = new AuthenticationException(
+            throw new AuthenticationException(
                     ADALError.ACTIVITY_REQUEST_INTENT_DATA_IS_NULL,
                     "Auth context verification failed. Did you set a context activity?");
-            throw authenticationException;
         }
     }
 
@@ -160,7 +159,7 @@ public class AuthenticationManager {
      * In case of an error, it falls back to {@link AuthenticationManager#authenticatePrompt(AuthenticationCallback)}.
      * @param authenticationCallback The callback to notify when the processing is finished.
      */
-    private void authenticateSilent(final AuthenticationCallback authenticationCallback) {
+    private void authenticateSilent(final AuthenticationCallback<AuthenticationResult> authenticationCallback) {
         getAuthenticationContext().acquireTokenSilent(
                 this.mResourceId,
                 Constants.CLIENT_ID,
@@ -195,7 +194,7 @@ public class AuthenticationManager {
      * Calls acquireToken to prompt the user for credentials.
      * @param authenticationCallback The callback to notify when the processing is finished.
      */
-    private void authenticatePrompt(final AuthenticationCallback authenticationCallback) {
+    private void authenticatePrompt(final AuthenticationCallback<AuthenticationResult> authenticationCallback) {
         getAuthenticationContext().acquireToken(
                 this.mResourceId,
                 Constants.CLIENT_ID,

--- a/app/src/main/java/com/microsoft/office365/connect/AuthenticationManager.java
+++ b/app/src/main/java/com/microsoft/office365/connect/AuthenticationManager.java
@@ -11,7 +11,6 @@ import android.util.Log;
 import android.webkit.CookieManager;
 import android.webkit.CookieSyncManager;
 
-import com.google.common.util.concurrent.SettableFuture;
 import com.microsoft.aad.adal.ADALError;
 import com.microsoft.aad.adal.AuthenticationCallback;
 import com.microsoft.aad.adal.AuthenticationContext;
@@ -27,17 +26,17 @@ import com.microsoft.services.odata.interfaces.LogLevel;
  * Handles setup of ADAL Dependency Resolver for use in API clients.
  */
 
-public class AuthenticationController {
-    private static String TAG = "AuthenticationController";
+public class AuthenticationManager {
+    private static String TAG = "AuthenticationManager";
 
     private AuthenticationContext authContext;
     private ADALDependencyResolver dependencyResolver;
     private Activity contextActivity;
     private String resourceId;
 
-    public static synchronized AuthenticationController getInstance() {
+    public static synchronized AuthenticationManager getInstance() {
         if (INSTANCE == null) {
-            INSTANCE = new AuthenticationController();
+            INSTANCE = new AuthenticationManager();
         }
         return INSTANCE;
     }
@@ -46,13 +45,13 @@ public class AuthenticationController {
         INSTANCE = null;
     }
 
-    private static AuthenticationController INSTANCE;
+    private static AuthenticationManager INSTANCE;
 
-    private AuthenticationController() {
+    private AuthenticationManager() {
         resourceId = Constants.DISCOVERY_RESOURCE_ID;
     }
 
-    private AuthenticationController(final Activity contextActivity){
+    private AuthenticationManager(final Activity contextActivity){
         this();
         this.contextActivity = contextActivity;
     }
@@ -187,7 +186,7 @@ public class AuthenticationController {
         //Reset controller objects.
         MailController.resetInstance();
         DiscoveryController.resetInstance();
-        AuthenticationController.resetInstance();
+        AuthenticationManager.resetInstance();
 
         //Clear cookies.
         if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP){

--- a/app/src/main/java/com/microsoft/office365/connect/AuthenticationManager.java
+++ b/app/src/main/java/com/microsoft/office365/connect/AuthenticationManager.java
@@ -196,12 +196,11 @@ public class AuthenticationManager {
      */
     private void authenticatePrompt(final AuthenticationCallback<AuthenticationResult> authenticationCallback) {
         getAuthenticationContext().acquireToken(
+                this.mContextActivity,
                 this.mResourceId,
                 Constants.CLIENT_ID,
                 Constants.REDIRECT_URI,
-                null,
                 PromptBehavior.Always,
-                null,
                 new AuthenticationCallback<AuthenticationResult>() {
                     @Override
                     public void onSuccess(final AuthenticationResult authenticationResult) {

--- a/app/src/main/java/com/microsoft/office365/connect/AuthenticationManager.java
+++ b/app/src/main/java/com/microsoft/office365/connect/AuthenticationManager.java
@@ -152,11 +152,12 @@ public class AuthenticationManager {
      */
     private void authenticatePrompt(final AuthenticationCallback authenticationCallback) {
         getAuthenticationContext().acquireToken(
-                this.mContextActivity,
                 this.mResourceId,
                 Constants.CLIENT_ID,
                 Constants.REDIRECT_URI,
+                null,
                 PromptBehavior.Always,
+                null,
                 new AuthenticationCallback<AuthenticationResult>() {
                     @Override
                     public void onSuccess(final AuthenticationResult authenticationResult) {

--- a/app/src/main/java/com/microsoft/office365/connect/AuthenticationManager.java
+++ b/app/src/main/java/com/microsoft/office365/connect/AuthenticationManager.java
@@ -125,6 +125,10 @@ public class AuthenticationManager {
                     @Override
                     public void onSuccess(final AuthenticationResult authenticationResult) {
                         if (authenticationResult != null && authenticationResult.getStatus() == AuthenticationStatus.Succeeded) {
+                            mDependencyResolver = new ADALDependencyResolver(
+                                    getAuthenticationContext(),
+                                    mResourceId,
+                                    Constants.CLIENT_ID);
                             authenticationCallback.onSuccess(authenticationResult);
                         } else if (authenticationResult != null) {
                             // I could not authenticate the user silently,
@@ -171,6 +175,7 @@ public class AuthenticationManager {
                             );
                         }
                     }
+
                     @Override
                     public void onError(Exception e) {
                         authenticationCallback.onError(e);
@@ -215,15 +220,6 @@ public class AuthenticationManager {
         AuthenticationManager.resetInstance();
 
         setIsUserConnected(false);
-
-        //Clear cookies.
-        if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP){
-            CookieManager.getInstance().removeSessionCookies(null);
-            CookieManager.getInstance().flush();
-        }else{
-            CookieManager.getInstance().removeSessionCookie();
-            CookieSyncManager.getInstance().sync();
-        }
     }
 
     private boolean verifyAuthenticationContext() {

--- a/app/src/main/java/com/microsoft/office365/connect/AuthenticationManager.java
+++ b/app/src/main/java/com/microsoft/office365/connect/AuthenticationManager.java
@@ -96,7 +96,7 @@ public class AuthenticationManager {
      */
     public void connect(final AuthenticationCallback authenticationCallback) {
         if (verifyAuthenticationContext()) {
-            if(isUserConnected()) {
+            if(isConnected()) {
                 authenticateSilent(authenticationCallback);
             } else {
                 authenticatePrompt(authenticationCallback);
@@ -239,7 +239,7 @@ public class AuthenticationManager {
         return true;
     }
 
-    private boolean isUserConnected(){
+    private boolean isConnected(){
         SharedPreferences settings = this
                 .mContextActivity
                 .getSharedPreferences(PREFERENCES_FILENAME, Context.MODE_PRIVATE);

--- a/app/src/main/java/com/microsoft/office365/connect/AuthenticationManager.java
+++ b/app/src/main/java/com/microsoft/office365/connect/AuthenticationManager.java
@@ -272,9 +272,7 @@ public class AuthenticationManager {
             getAuthenticationContext().getCache().removeAll();
         }
 
-        // Reset controller objects.
-        MailController.resetInstance();
-        DiscoveryController.resetInstance();
+        // Reset the AuthenticationManager object
         AuthenticationManager.resetInstance();
 
         // Forget the user

--- a/app/src/main/java/com/microsoft/office365/connect/ConnectActivity.java
+++ b/app/src/main/java/com/microsoft/office365/connect/ConnectActivity.java
@@ -4,9 +4,7 @@
 package com.microsoft.office365.connect;
 
 import android.content.Intent;
-import android.os.Build;
 import android.os.Bundle;
-import android.provider.Settings;
 import android.support.v7.app.ActionBarActivity;
 import android.util.Log;
 import android.view.View;
@@ -17,9 +15,7 @@ import android.widget.Toast;
 
 import com.microsoft.aad.adal.AuthenticationCallback;
 import com.microsoft.aad.adal.AuthenticationResult;
-import com.microsoft.aad.adal.AuthenticationSettings;
 
-import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.util.UUID;
 
@@ -45,20 +41,6 @@ public class ConnectActivity extends ActionBarActivity {
         setContentView(R.layout.activity_connect);
 
         initializeViews();
-
-        // Devices with API level lower than 18 must setup an encryption key.
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN_MR2 &&
-                AuthenticationSettings.INSTANCE.getSecretKeyData() == null) {
-                AuthenticationSettings.INSTANCE.setSecretKey(generateSecretKey());
-        }
-
-        // We're not using Microsoft Intune's Company portal app,
-        // skip the broker check so we don't get warnings about the following permissions
-        // in manifest:
-        // GET_ACCOUNTS
-        // USE_CREDENTIALS
-        // MANAGE_ACCOUNTS
-        AuthenticationSettings.INSTANCE.setSkipBroker(true);
     }
 
     /**
@@ -118,32 +100,6 @@ public class ConnectActivity extends ActionBarActivity {
                 });
     }
 
-    /**
-     * Generates an encryption key for devices with API level lower than 18 using the
-     * ANDROID_ID value as a seed.
-     * In production scenarios, you should come up with your own implementation of this method.
-     * Consider that your algorithm must return the same key so it can encrypt/decrypt values
-     * successfully.
-     * @return The encryption key in a 32 byte long array.
-     */
-    private byte[] generateSecretKey() {
-        byte[] key = new byte[32];
-        byte[] android_id = null;
-
-        try{
-            android_id = Settings.Secure.ANDROID_ID.getBytes("UTF-8");
-        } catch (UnsupportedEncodingException e){
-            Log.e(TAG, "generateSecretKey - " + e.getMessage());
-            showEncryptionKeyErrorUI();
-        }
-
-        for(int i = 0; i < key.length; i++){
-            key[i] = android_id[i % android_id.length];
-        }
-
-        return key;
-    }
-
     private void initializeViews(){
         mConnectButton = (Button)findViewById(R.id.connectButton);
         mConnectProgressBar = (ProgressBar)findViewById(R.id.connectProgressBar);
@@ -163,17 +119,6 @@ public class ConnectActivity extends ActionBarActivity {
         mTitleTextView.setVisibility(View.GONE);
         mDescriptionTextView.setVisibility(View.GONE);
         mConnectProgressBar.setVisibility(View.VISIBLE);
-    }
-
-    private void showEncryptionKeyErrorUI(){
-        mTitleTextView.setText(R.string.title_text_error);
-        mTitleTextView.setVisibility(View.VISIBLE);
-        mDescriptionTextView.setText(R.string.connect_text_error);
-        mDescriptionTextView.setVisibility(View.VISIBLE);
-        Toast.makeText(
-                ConnectActivity.this,
-                R.string.encryption_key_text_error,
-                Toast.LENGTH_LONG).show();
     }
 
     private void showConnectErrorUI(){

--- a/app/src/main/java/com/microsoft/office365/connect/ConnectActivity.java
+++ b/app/src/main/java/com/microsoft/office365/connect/ConnectActivity.java
@@ -59,8 +59,6 @@ public class ConnectActivity extends ActionBarActivity {
         // USE_CREDENTIALS
         // MANAGE_ACCOUNTS
         AuthenticationSettings.INSTANCE.setSkipBroker(true);
-
-        AuthenticationManager.getInstance().setContextActivity(this);
     }
 
     /**
@@ -86,6 +84,7 @@ public class ConnectActivity extends ActionBarActivity {
         }
 
         final Intent sendMailIntent = new Intent(this, SendMailActivity.class);
+        AuthenticationManager.getInstance().setContextActivity(this);
 
         AuthenticationManager.getInstance().connect(
                 new AuthenticationCallback<AuthenticationResult>() {
@@ -114,8 +113,6 @@ public class ConnectActivity extends ActionBarActivity {
                     @Override
                     public void onError(final Exception e) {
                         Log.e(TAG, "onCreate - " + e.getMessage());
-                        // We need to make sure that there is no data stored with the failed auth
-                        AuthenticationManager.getInstance().disconnect();
                         showConnectErrorUI();
                     }
                 });

--- a/app/src/main/java/com/microsoft/office365/connect/ConnectActivity.java
+++ b/app/src/main/java/com/microsoft/office365/connect/ConnectActivity.java
@@ -61,7 +61,7 @@ public class ConnectActivity extends ActionBarActivity {
         // MANAGE_ACCOUNTS
         AuthenticationSettings.INSTANCE.setSkipBroker(true);
 
-        AuthenticationManager.getInstance().enableLogging(LogLevel.VERBOSE);
+        AuthenticationManager.getInstance().setContextActivity(this);
     }
 
     /**
@@ -88,7 +88,6 @@ public class ConnectActivity extends ActionBarActivity {
 
         final Intent sendMailIntent = new Intent(this, SendMailActivity.class);
 
-        AuthenticationManager.getInstance().setContextActivity(this);
         AuthenticationManager.getInstance().connect(
                 new AuthenticationCallback<AuthenticationResult>() {
                     /**

--- a/app/src/main/java/com/microsoft/office365/connect/ConnectActivity.java
+++ b/app/src/main/java/com/microsoft/office365/connect/ConnectActivity.java
@@ -100,6 +100,25 @@ public class ConnectActivity extends ActionBarActivity {
                 });
     }
 
+    /**
+     * This activity gets notified about the completion of the ADAL activity through this method.
+     * @param requestCode The integer request code originally supplied to startActivityForResult(),
+     *                    allowing you to identify who this result came from.
+     * @param resultCode The integer result code returned by the child activity through its
+     *                   setResult().
+     * @param data An Intent, which can return result data to the caller (various data
+     *             can be attached to Intent "extras").
+     */
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+        Log.i(TAG, "onActivityResult - AuthenticationActivity has come back with results");
+        super.onActivityResult(requestCode, resultCode, data);
+        AuthenticationManager
+                .getInstance()
+                .getAuthenticationContext()
+                .onActivityResult(requestCode, resultCode, data);
+    }
+
     private void initializeViews(){
         mConnectButton = (Button)findViewById(R.id.connectButton);
         mConnectProgressBar = (ProgressBar)findViewById(R.id.connectProgressBar);

--- a/app/src/main/java/com/microsoft/office365/connect/ConnectActivity.java
+++ b/app/src/main/java/com/microsoft/office365/connect/ConnectActivity.java
@@ -18,7 +18,6 @@ import android.widget.Toast;
 import com.microsoft.aad.adal.AuthenticationCallback;
 import com.microsoft.aad.adal.AuthenticationResult;
 import com.microsoft.aad.adal.AuthenticationSettings;
-import com.microsoft.services.odata.interfaces.LogLevel;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
@@ -115,30 +114,11 @@ public class ConnectActivity extends ActionBarActivity {
                     @Override
                     public void onError(final Exception e) {
                         Log.e(TAG, "onCreate - " + e.getMessage());
-                        // We need to make sure that there are no cookies stored with the failed auth
+                        // We need to make sure that there is no data stored with the failed auth
                         AuthenticationManager.getInstance().disconnect();
                         showConnectErrorUI();
                     }
                 });
-    }
-
-    /**
-     * This activity gets notified about the completion of the ADAL activity through this method.
-     * @param requestCode The integer request code originally supplied to startActivityForResult(),
-     *                    allowing you to identify who this result came from.
-     * @param resultCode The integer result code returned by the child activity through its
-     *                   setResult().
-     * @param data An Intent, which can return result data to the caller (various data
-     *             can be attached to Intent "extras").
-     */
-    @Override
-    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
-        Log.i(TAG, "onActivityResult - AuthenticationActivity has come back with results");
-        super.onActivityResult(requestCode, resultCode, data);
-        AuthenticationManager
-                .getInstance()
-                .getAuthenticationContext()
-                .onActivityResult(requestCode, resultCode, data);
     }
 
     /**

--- a/app/src/main/java/com/microsoft/office365/connect/ConnectActivity.java
+++ b/app/src/main/java/com/microsoft/office365/connect/ConnectActivity.java
@@ -5,7 +5,7 @@ package com.microsoft.office365.connect;
 
 import android.content.Intent;
 import android.os.Bundle;
-import android.support.v7.app.ActionBarActivity;
+import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
 import android.view.View;
 import android.widget.Button;
@@ -26,7 +26,7 @@ import java.util.UUID;
  * If there are cached tokens, the app tries to reuse them.
  * The activity redirects the user to the SendMailActivity upon successful connection.
  */
-public class ConnectActivity extends ActionBarActivity {
+public class ConnectActivity extends AppCompatActivity {
 
     private static final String TAG = "ConnectActivity";
 

--- a/app/src/main/java/com/microsoft/office365/connect/ConnectActivity.java
+++ b/app/src/main/java/com/microsoft/office365/connect/ConnectActivity.java
@@ -15,9 +15,6 @@ import android.widget.ProgressBar;
 import android.widget.TextView;
 import android.widget.Toast;
 
-import com.google.common.util.concurrent.FutureCallback;
-import com.google.common.util.concurrent.Futures;
-import com.google.common.util.concurrent.SettableFuture;
 import com.microsoft.aad.adal.AuthenticationCallback;
 import com.microsoft.aad.adal.AuthenticationResult;
 import com.microsoft.aad.adal.AuthenticationSettings;
@@ -64,7 +61,7 @@ public class ConnectActivity extends ActionBarActivity {
         // MANAGE_ACCOUNTS
         AuthenticationSettings.INSTANCE.setSkipBroker(true);
 
-        AuthenticationController.getInstance().enableLogging(LogLevel.VERBOSE);
+        AuthenticationManager.getInstance().enableLogging(LogLevel.VERBOSE);
     }
 
     /**
@@ -91,8 +88,8 @@ public class ConnectActivity extends ActionBarActivity {
 
         final Intent sendMailIntent = new Intent(this, SendMailActivity.class);
 
-        AuthenticationController.getInstance().setContextActivity(this);
-        AuthenticationController.getInstance().initialize(
+        AuthenticationManager.getInstance().setContextActivity(this);
+        AuthenticationManager.getInstance().initialize(
                 new AuthenticationCallback<AuthenticationResult>() {
                     /**
                      * If the connection is successful, the activity extracts the username and
@@ -120,7 +117,7 @@ public class ConnectActivity extends ActionBarActivity {
                     public void onError(final Exception e) {
                         Log.e(TAG, "onCreate - " + e.getMessage());
                         // We need to make sure that there are no cookies stored with the failed auth
-                        AuthenticationController.getInstance().disconnect();
+                        AuthenticationManager.getInstance().disconnect();
                         showConnectErrorUI();
                     }
                 });
@@ -139,7 +136,7 @@ public class ConnectActivity extends ActionBarActivity {
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
         Log.i(TAG, "onActivityResult - AuthenticationActivity has come back with results");
         super.onActivityResult(requestCode, resultCode, data);
-        AuthenticationController
+        AuthenticationManager
                 .getInstance()
                 .getAuthenticationContext()
                 .onActivityResult(requestCode, resultCode, data);

--- a/app/src/main/java/com/microsoft/office365/connect/ConnectActivity.java
+++ b/app/src/main/java/com/microsoft/office365/connect/ConnectActivity.java
@@ -89,7 +89,7 @@ public class ConnectActivity extends ActionBarActivity {
         final Intent sendMailIntent = new Intent(this, SendMailActivity.class);
 
         AuthenticationManager.getInstance().setContextActivity(this);
-        AuthenticationManager.getInstance().initialize(
+        AuthenticationManager.getInstance().connect(
                 new AuthenticationCallback<AuthenticationResult>() {
                     /**
                      * If the connection is successful, the activity extracts the username and

--- a/app/src/main/java/com/microsoft/office365/connect/DiscoveryController.java
+++ b/app/src/main/java/com/microsoft/office365/connect/DiscoveryController.java
@@ -70,8 +70,8 @@ public class DiscoveryController {
                 result.setException(noSuchElementException);
             }
         } else { // The services have not been cached yet. Go ask the discovery service.
-            AuthenticationController.getInstance().setResourceId(Constants.DISCOVERY_RESOURCE_ID);
-            ADALDependencyResolver dependencyResolver = (ADALDependencyResolver) AuthenticationController
+            AuthenticationManager.getInstance().setResourceId(Constants.DISCOVERY_RESOURCE_ID);
+            ADALDependencyResolver dependencyResolver = (ADALDependencyResolver) AuthenticationManager
                     .getInstance()
                     .getDependencyResolver();
 

--- a/app/src/main/java/com/microsoft/office365/connect/DiscoveryController.java
+++ b/app/src/main/java/com/microsoft/office365/connect/DiscoveryController.java
@@ -34,10 +34,6 @@ public class DiscoveryController {
         return INSTANCE;
     }
 
-    public static synchronized void resetInstance() {
-        INSTANCE = null;
-    }
-
     private static DiscoveryController INSTANCE;
 
     /**

--- a/app/src/main/java/com/microsoft/office365/connect/MailController.java
+++ b/app/src/main/java/com/microsoft/office365/connect/MailController.java
@@ -41,10 +41,6 @@ public class MailController {
         return INSTANCE;
     }
 
-    public static synchronized void resetInstance() {
-        INSTANCE = null;
-    }
-
     private static MailController INSTANCE;
 
     /**

--- a/app/src/main/java/com/microsoft/office365/connect/MailController.java
+++ b/app/src/main/java/com/microsoft/office365/connect/MailController.java
@@ -93,8 +93,8 @@ public class MailController {
         final SettableFuture<Boolean> result = SettableFuture.create();
 
         try {
-            AuthenticationController.getInstance().setResourceId(mServiceResourceId);
-            ADALDependencyResolver dependencyResolver = (ADALDependencyResolver) AuthenticationController
+            AuthenticationManager.getInstance().setResourceId(mServiceResourceId);
+            ADALDependencyResolver dependencyResolver = (ADALDependencyResolver) AuthenticationManager
                     .getInstance()
                     .getDependencyResolver();
 

--- a/app/src/main/java/com/microsoft/office365/connect/SendMailActivity.java
+++ b/app/src/main/java/com/microsoft/office365/connect/SendMailActivity.java
@@ -5,7 +5,7 @@ package com.microsoft.office365.connect;
 
 import android.content.Intent;
 import android.os.Bundle;
-import android.support.v7.app.ActionBarActivity;
+import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -30,7 +30,7 @@ import java.util.concurrent.ExecutionException;
  * The activity uses the DiscoveryController class to get the service endpoint. It also
  * uses the MailController to send the message.
  */
-public class SendMailActivity extends ActionBarActivity {
+public class SendMailActivity extends AppCompatActivity {
 
     private static final String TAG = "SendMailActivity";
 

--- a/app/src/main/java/com/microsoft/office365/connect/SendMailActivity.java
+++ b/app/src/main/java/com/microsoft/office365/connect/SendMailActivity.java
@@ -4,15 +4,12 @@
 package com.microsoft.office365.connect;
 
 import android.content.Intent;
-import android.os.Build;
 import android.os.Bundle;
 import android.support.v7.app.ActionBarActivity;
 import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
-import android.webkit.CookieManager;
-import android.webkit.CookieSyncManager;
 import android.widget.EditText;
 import android.widget.ImageButton;
 import android.widget.ProgressBar;
@@ -21,7 +18,6 @@ import android.widget.Toast;
 
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
-import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import com.microsoft.discoveryservices.ServiceInfo;
 
@@ -132,7 +128,7 @@ public class SendMailActivity extends ActionBarActivity {
         try {
             switch (item.getItemId()) {
                 case R.id.disconnectMenuitem:
-                    AuthenticationController.getInstance().disconnect();
+                    AuthenticationManager.getInstance().disconnect();
                     showDisconnectSuccessUI();
                     Intent connectIntent = new Intent(this, ConnectActivity.class);
                     startActivity(connectIntent);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -23,7 +23,6 @@
     <string name="sendmail_text_error">\nSorry, can\'t send the email.\nHint: Check logcat for details.</string>
 
     <!-- Toast error messages -->
-    <string name="encryption_key_text_error">Error setting up encryption key\nCheck logcat for details</string>
     <string name="connect_toast_text_error">Error connecting to Office 365\nCheck logcat for details</string>
     <string name="discover_toast_text_error">Error finding mail service\nCheck logcat for details</string>
     <string name="send_mail_toast_text_error">Error sending email\nCheck logcat for details</string>


### PR DESCRIPTION
In this PR I implemented an explicit pattern to interact with ADAL that gives app developers more control on when and how to present a sign in page instead of relying on the automatic prompt behavior.
I also updated the code to use the more familiar callbacks instead of the Guava library (only in auth code, for now).
