### PR TITLE
Added  to manifest to override the setting from the libraries

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,7 +4,8 @@
    - See LICENSE in the project root for license information.
   -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.microsoft.office365.connect" >
+          xmlns:tools="http://schemas.android.com/tools"
+          package="com.microsoft.office365.connect">
 
     <!-- Required to connect to Office 365 -->
     <uses-permission android:name="android.permission.INTERNET" />
@@ -12,7 +13,8 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
     <application
-        android:allowBackup="true"
+        tools:replace="android:allowBackup"
+        android:allowBackup="false"
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name"
         android:theme="@style/AppTheme" >


### PR DESCRIPTION
The Office 365 SDK and ADAL for Android set the attribute `android:allowBackup` to true, which prevents the app that consumes them to specify its preferred value.

As a workaround, we can override that setting with `tools:replace="android:allowBackup"`. However, we shouldn't need to do that if the setting is not enforced from the libraries.

See the following issues for more information: 
- Officedev/Office-365-SDK-for-Android#96
- AzureAD/azure-activedirectory-library-for-android#472
